### PR TITLE
Check if the uploaded file is valid

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -27,7 +27,7 @@ class Migrator():
 
         for upload in uploads:
             if upload["store"] == "GridFS:Uploads":
-                if upload["complete"] is True:
+                if "complete" in upload and upload["complete"] is True:
                     path = upload["path"]
                     pathSegments = path.split("/")
                     gridfsId = pathSegments[3]
@@ -46,6 +46,8 @@ class Migrator():
                         file.write(data)
                         file.close()
                         self.addtolog(gridfsId, filename, collection, res.md5)
+                else:
+                    print(upload)
         self.writelog()
 
     def addtolog(self, dbId, filename, collection, md5):


### PR DESCRIPTION
If the uploaded file is broken or the whole instance is based on a slack import, the file object does not have a "complete" attribute. 
We should skip invalid files and print the objects out.