### PR TITLE
fix db timeout for very large migrations

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -99,7 +99,7 @@ class Migrator():
         uploadsCollection = db[collection]
         fs = gridfs.GridFSBucket(db, bucket_name=collection)
 
-        uploads = uploadsCollection.find({}, no_cursor_timeout=True)
+        uploads = uploadsCollection.find({}, no_cursor_timeout=True).batch_size(50)
 
         i = 0
         for upload in uploads:


### PR DESCRIPTION
I did experienced an cursor timeout after some time (>1h) reducing the batch size on the cursor solved the issue.

```
...
26175. Dumping cYLJWRAJfMrJoJk2L Screenshot 2020-06-19 at 10.48.01.png
Traceback (most recent call last):
  File "./migrate.py", line 243, in <module>
    obj.dumpfiles("rocketchat_uploads", store)
  File "./migrate.py", line 109, in dumpfiles
    for upload in uploads:
  File "/usr/local/lib/python3.8/dist-packages/pymongo/cursor.py", line 1159, in next
    if len(self.__data) or self._refresh():
  File "/usr/local/lib/python3.8/dist-packages/pymongo/cursor.py", line 1100, in _refresh
    self.__send_message(g)
  File "/usr/local/lib/python3.8/dist-packages/pymongo/cursor.py", line 971, in __send_message
    response = client._run_operation(
  File "/usr/local/lib/python3.8/dist-packages/pymongo/mongo_client.py", line 1215, in _run_operation
    return self._retryable_read(
  File "/usr/local/lib/python3.8/dist-packages/pymongo/mongo_client.py", line 1313, in _retryable_read
    return func(session, server, sock_info, secondary_ok)
  File "/usr/local/lib/python3.8/dist-packages/pymongo/mongo_client.py", line 1211, in _cmd
    return server.run_operation(
  File "/usr/local/lib/python3.8/dist-packages/pymongo/server.py", line 129, in run_operation
    _check_command_response(first, sock_info.max_wire_version)
  File "/usr/local/lib/python3.8/dist-packages/pymongo/helpers.py", line 168, in _check_command_response
    raise CursorNotFound(errmsg, code, response, max_wire_version)
pymongo.errors.CursorNotFound: cursor id 205731453972 not found, full error: {'operationTime': Timestamp(1642418883, 1), 'ok': 0.0, 'errmsg': 'cursor id 205731453972 not found', 'code': 43, 'codeName': 'CursorNotFound', '$clusterTime': {'clusterTime': Timestamp(1642418883, 1), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}}
```