### PR TITLE
fixed failed S3 upload when content type is not set in gridfs

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -65,11 +65,15 @@ class AmazonS3Store():
     def put(self, filename, data, entry):
         key = self.uniqueID + "/uploads/" + entry['rid'] + "/" + entry[
             'userId'] + "/" + entry['_id']
-        self.s3.Object(self.bucket, key).put(
-            Body=data,
-            ContentType=entry['type'],
-            ContentDisposition='inline; filename="' + self.encodeURI(
-                entry['name']) + '"')
+        if 'type' in entry.keys:
+            self.s3.Object(self.bucket, key).put(
+                Body=data,
+                ContentType=entry['type'],
+                ContentDisposition='inline; filename="' + self.encodeURI(entry['name']) + '"')
+        else:
+            self.s3.Object(self.bucket, key).put(
+                Body=data,
+                ContentDisposition='inline; filename="' + self.encodeURI(entry['name']) + '"')
         return key
 
 

--- a/migrate.py
+++ b/migrate.py
@@ -65,7 +65,7 @@ class AmazonS3Store():
     def put(self, filename, data, entry):
         key = self.uniqueID + "/uploads/" + entry['rid'] + "/" + entry[
             'userId'] + "/" + entry['_id']
-        if 'type' in entry.keys:
+        if 'type' in entry.keys():
             self.s3.Object(self.bucket, key).put(
                 Body=data,
                 ContentType=entry['type'],


### PR DESCRIPTION
I encountered an issue where the content_type does not seemed to be set in mongo/gridfs

```
8. Dumping 6MZXqQpFhSRZ6mvCm xxxxxxx
Traceback (most recent call last):
  File "./migrate.py", line 239, in <module>
    obj.dumpfiles("rocketchat_uploads", store)
  File "./migrate.py", line 120, in dumpfiles
    key = store.put(filename, data, upload)
  File "./migrate.py", line 70, in put
    ContentType=entry['type'],
KeyError: 'type'
```